### PR TITLE
[gettext]: Add inspec tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,13 @@
-# base-plan-skeleton
-Template for all new Chef Base Plans to simplify creation of repositories.
+# gettext
+
+## Maintainers
+
+* The Habitat Maintainers: <humans@habitat.sh>
+
+## Type of Package
+
+Binary package
+
+## Usage
+
+*TODO: Add instructions for usage*

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Build Status](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_apis/build/status/chef-base-plans.gettext?branchName=master)](https://dev.azure.com/chefcorp-partnerengineering/Chef%20Base%20Plans/_build/latest?definitionId=69&branchName=master)
+
 # gettext
 
 ## Maintainers

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,0 +1,1 @@
+command_path: '/bin/gettext'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_relative_path: '/bin/gettext'
+command_relative_path: 'bin/gettext'

--- a/attributes.yml
+++ b/attributes.yml
@@ -1,1 +1,1 @@
-command_path: '/bin/gettext'
+command_relative_path: '/bin/gettext'

--- a/controls/gettext_exists.rb
+++ b/controls/gettext_exists.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gettext exists'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gettext')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-command_relative_path = input('command_relative_path', value: '/bin/gettext')
-command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
 
 control 'core-plans-gettext-exists' do
   impact 1.0
@@ -12,11 +9,14 @@ control 'core-plans-gettext-exists' do
   desc '
   Verify gettext by ensuring /bin/gettext exists'
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
 
+  command_relative_path = input('command_relative_path', value: '/bin/gettext')
+  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/gettext_exists.rb
+++ b/controls/gettext_exists.rb
@@ -13,6 +13,7 @@ control 'core-plans-gettext-exists' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
 
   command_relative_path = input('command_relative_path', value: 'bin/gettext')

--- a/controls/gettext_exists.rb
+++ b/controls/gettext_exists.rb
@@ -1,17 +1,23 @@
 title 'Tests to confirm gettext exists'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gettext')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
-gettext_relative_path = input('command_path', value: '/bin/gettext')
-gettext_installation_directory = command("hab pkg path #{plan_ident}")
-gettext_full_path = gettext_installation_directory.stdout.strip + "#{ gettext_relative_path}"
- 
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+command_relative_path = input('command_relative_path', value: '/bin/gettext')
+command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+
 control 'core-plans-gettext-exists' do
   impact 1.0
   title 'Ensure gettext exists'
   desc '
-  '
-   describe file(gettext_full_path) do
+  Verify gettext by ensuring /bin/gettext exists'
+  
+  describe plan_installation_directory do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+
+  describe file(command_full_path) do
     it { should exist }
   end
 end

--- a/controls/gettext_exists.rb
+++ b/controls/gettext_exists.rb
@@ -1,0 +1,17 @@
+title 'Tests to confirm gettext exists'
+
+plan_name = input('plan_name', value: 'gettext')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+gettext_relative_path = input('command_path', value: '/bin/gettext')
+gettext_installation_directory = command("hab pkg path #{plan_ident}")
+gettext_full_path = gettext_installation_directory.stdout.strip + "#{ gettext_relative_path}"
+ 
+control 'core-plans-gettext-exists' do
+  impact 1.0
+  title 'Ensure gettext exists'
+  desc '
+  '
+   describe file(gettext_full_path) do
+    it { should exist }
+  end
+end

--- a/controls/gettext_exists.rb
+++ b/controls/gettext_exists.rb
@@ -7,7 +7,7 @@ control 'core-plans-gettext-exists' do
   impact 1.0
   title 'Ensure gettext exists'
   desc '
-  Verify gettext by ensuring /bin/gettext exists'
+  Verify gettext by ensuring bin/gettext exists'
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
@@ -15,8 +15,8 @@ control 'core-plans-gettext-exists' do
     its('stdout') { should_not be_empty }
   end
 
-  command_relative_path = input('command_relative_path', value: '/bin/gettext')
-  command_full_path = plan_installation_directory.stdout.strip + "#{command_relative_path}"
+  command_relative_path = input('command_relative_path', value: 'bin/gettext')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
   describe file(command_full_path) do
     it { should exist }
   end

--- a/controls/gettext_works.rb
+++ b/controls/gettext_works.rb
@@ -1,24 +1,28 @@
 title 'Tests to confirm gettext works as expected'
 
+plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gettext')
-plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
+plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gettext-works' do
   impact 1.0
   title 'Ensure gettext works as expected'
   desc '
+  Verify gettext by ensuring (1) its installation directory exists and (2) that
+  it returns the expected version
   '
-  gettext_path = command("hab pkg path #{plan_ident}")
-  describe gettext_path do
+  
+  describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
-  gettext_pkg_ident = ((gettext_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  describe command("DEBUG=true; hab pkg exec #{ gettext_pkg_ident} gettext --version") do
+  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gettext --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
-    its('stdout') { should match /gettext \(GNU gettext-runtime\) 0.20.1/ }
+    its('stdout') { should match /gettext \(GNU gettext-runtime\) #{plan_pkg_version}/ }
     its('stderr') { should be_empty }
   end
 end

--- a/controls/gettext_works.rb
+++ b/controls/gettext_works.rb
@@ -2,9 +2,6 @@ title 'Tests to confirm gettext works as expected'
 
 plan_origin = ENV['HAB_ORIGIN']
 plan_name = input('plan_name', value: 'gettext')
-plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
-plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
 
 control 'core-plans-gettext-works' do
   impact 1.0
@@ -14,11 +11,14 @@ control 'core-plans-gettext-works' do
   it returns the expected version
   '
   
+  plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
   end
   
+  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
   describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gettext --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }

--- a/controls/gettext_works.rb
+++ b/controls/gettext_works.rb
@@ -16,6 +16,7 @@ control 'core-plans-gettext-works' do
   describe plan_installation_directory do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
+    its('stderr') { should be_empty }
   end
   
   command_relative_path = input('command_relative_path', value: 'bin/gettext')

--- a/controls/gettext_works.rb
+++ b/controls/gettext_works.rb
@@ -1,0 +1,24 @@
+title 'Tests to confirm gettext works as expected'
+
+plan_name = input('plan_name', value: 'gettext')
+plan_ident = "#{ENV['HAB_ORIGIN']}/#{plan_name}"
+
+control 'core-plans-gettext-works' do
+  impact 1.0
+  title 'Ensure gettext works as expected'
+  desc '
+  '
+  gettext_path = command("hab pkg path #{plan_ident}")
+  describe gettext_path do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+  end
+  
+  gettext_pkg_ident = ((gettext_path.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
+  describe command("DEBUG=true; hab pkg exec #{ gettext_pkg_ident} gettext --version") do
+    its('exit_status') { should eq 0 }
+    its('stdout') { should_not be_empty }
+    its('stdout') { should match /gettext \(GNU gettext-runtime\) 0.20.1/ }
+    its('stderr') { should be_empty }
+  end
+end

--- a/controls/gettext_works.rb
+++ b/controls/gettext_works.rb
@@ -7,8 +7,9 @@ control 'core-plans-gettext-works' do
   impact 1.0
   title 'Ensure gettext works as expected'
   desc '
-  Verify gettext by ensuring (1) its installation directory exists and (2) that
-  it returns the expected version
+  Verify gettext by ensuring 
+  (1) its installation directory exists and 
+  (2) that it returns the expected version.
   '
   
   plan_installation_directory = command("hab pkg path #{plan_origin}/#{plan_name}")
@@ -17,9 +18,10 @@ control 'core-plans-gettext-works' do
     its('stdout') { should_not be_empty }
   end
   
-  plan_pkg_ident = ((plan_installation_directory.stdout.strip).match /(?<=pkgs\/)(.*)/)[1]
-  plan_pkg_version = (plan_pkg_ident.match /^#{plan_origin}\/#{plan_name}\/(?<version>.*)\//)[:version]
-  describe command("DEBUG=true; hab pkg exec #{plan_pkg_ident} gettext --version") do
+  command_relative_path = input('command_relative_path', value: 'bin/gettext')
+  command_full_path = File.join(plan_installation_directory.stdout.strip, "#{command_relative_path}")
+  plan_pkg_version = plan_installation_directory.stdout.split("/")[5]
+  describe command("#{command_full_path} --version") do
     its('exit_status') { should eq 0 }
     its('stdout') { should_not be_empty }
     its('stdout') { should match /gettext \(GNU gettext-runtime\) #{plan_pkg_version}/ }

--- a/disable-test.patch
+++ b/disable-test.patch
@@ -1,0 +1,13 @@
+diff -ru gettext-0.19.8.orig/gettext-tools/tests/lang-gawk gettext-0.19.8/gettext-tools/tests/lang-gawk
+--- gettext-0.19.8.orig/gettext-tools/tests/lang-gawk	2018-03-24 04:09:42.123403813 +0000
++++ gettext-0.19.8/gettext-tools/tests/lang-gawk	2018-03-24 04:10:38.242652216 +0000
+@@ -1,6 +1,9 @@
+ #! /bin/sh
+ . "${srcdir=.}/init.sh"; path_prepend_ . ../src
+ 
++# Early exit
++Exit 0
++
+ # Test of gettext facilities in the GNU awk language.
+ # Assumes an fr_FR locale is installed.
+ # Assumes the following packages are installed: gawk.

--- a/inspec.yml
+++ b/inspec.yml
@@ -1,9 +1,9 @@
-name: {{plan_name}}
-title: Habitat Core Plan {{plan_name}}
-maintainer: humans@habitat.sh
-summary: InSpec controls for testing Habitat Core Plan {{plan_name}}
-copyright: humans@habitat.sh
-copyright_email: humans@habitat.sh
+name: gettext
+title: Habitat Core Plan gettext
+maintainer: "The Habitat Maintainers <humans@habitat.sh>"
+summary: InSpec controls for testing Habitat Core Plan gettext
+copyright: 2019, Chef Software, Inc.
+copyright_email: legal@chef.io
 version: 0.1.0
 license: Apache-2.0
 inspec_version: '>= 3.0.25'

--- a/plan.sh
+++ b/plan.sh
@@ -1,0 +1,61 @@
+pkg_name=gettext
+pkg_origin=core
+pkg_version=0.20.1
+pkg_maintainer="The Habitat Maintainers <humans@habitat.sh>"
+pkg_description="GNU internationalization library."
+pkg_upstream_url="http://www.gnu.org/software/gettext/"
+pkg_license=('GPL-2.0-or-later' 'LGPL-2.0-or-later')
+pkg_source="http://ftp.gnu.org/gnu/$pkg_name/${pkg_name}-${pkg_version}.tar.gz"
+pkg_shasum="66415634c6e8c3fa8b71362879ec7575e27da43da562c798a8a2f223e6e47f5c"
+pkg_deps=(
+  core/glibc
+  core/gcc-libs
+  core/acl
+  core/xz
+)
+pkg_build_deps=(
+  core/coreutils
+  core/diffutils
+  core/patch
+  core/make
+  core/gcc
+  core/sed
+  core/findutils
+)
+pkg_bin_dirs=(bin)
+pkg_lib_dirs=(lib)
+pkg_include_dirs=(include)
+
+do_prepare() {
+  do_default_prepare
+
+  patch -p1 -i "$PLAN_CONTEXT/disable-test.patch"
+}
+
+do_build() {
+  ./configure \
+    --prefix="$pkg_prefix"
+  make -j"$(nproc)"
+}
+
+do_check() {
+  make check
+}
+
+
+# ----------------------------------------------------------------------------
+# **NOTICE:** What follows are implementation details required for building a
+# first-pass, "stage1" toolchain and environment. It is only used when running
+# in a "stage1" Studio and can be safely ignored by almost everyone. Having
+# said that, it performs a vital bootstrapping process and cannot be removed or
+# significantly altered. Thank you!
+# ----------------------------------------------------------------------------
+if [[ "$STUDIO_TYPE" = "stage1" ]]; then
+  pkg_build_deps=(
+    core/gcc
+    core/coreutils
+    core/sed
+    core/diffutils
+    core/findutils
+  )
+fi

--- a/tests/test.bats
+++ b/tests/test.bats
@@ -1,0 +1,4 @@
+@test "gettext displays help" {
+  run hab pkg exec $TEST_PKG_IDENT gettext --help
+  [ "$status" -eq 0 ]
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -1,0 +1,18 @@
+#!/bin/sh
+#/ Usage: test.sh <pkg_ident>
+#/
+#/ Example: test.sh core/php/7.2.8/20181108151533
+#/
+
+set -euo pipefail
+
+if [[ -z "${1:-}" ]]; then
+  grep '^#/' < "${0}" | cut -c4-
+	exit 1
+fi
+
+TEST_PKG_IDENT="${1}"
+export TEST_PKG_IDENT
+hab pkg install core/bats --binlink
+hab pkg install "${TEST_PKG_IDENT}"
+bats "$(dirname "${0}")/test.bats"


### PR DESCRIPTION
```rspec
hab pkg exec chef/inspec inspec exec /src/. --chef-license=accept -t docker://f3887d8ecb8a2ffb26ddafa8e24d0c7b218611ad048b2a55586e7ff2c93a3f42 --input-file /src/attributes.yml

Profile: Habitat Core Plan gettext (gettext)
Version: 0.1.0
Target:  docker://f3887d8ecb8a2ffb26ddafa8e24d0c7b218611ad048b2a55586e7ff2c93a3f42

  ✔  core-plans-gettext-works: Ensure gettext works as expected
     ✔  Command: `hab pkg path core/gettext` exit_status is expected to eq 0
     ✔  Command: `hab pkg path core/gettext` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gettext/0.20.1/20200603163144 gettext --version` exit_status is expected to eq 0
     ✔  Command: `DEBUG=true; hab pkg exec core/gettext/0.20.1/20200603163144 gettext --version` stdout is expected not to be empty
     ✔  Command: `DEBUG=true; hab pkg exec core/gettext/0.20.1/20200603163144 gettext --version` stdout is expected to match /gettext \(GNU gettext-runtime\) 0.20.1/
     ✔  Command: `DEBUG=true; hab pkg exec core/gettext/0.20.1/20200603163144 gettext --version` stderr is expected to be empty
  ✔  core-plans-gettext-exists: Ensure gettext exists
     ✔  File /hab/pkgs/core/gettext/0.20.1/20200603163144/bin/gettext is expected to exist


Profile Summary: 2 successful controls, 0 control failures, 0 controls skipped
Test Summary: 7 successful, 0 failures, 0 skipped
+ set +x
[7][default:/src:0]# 
```